### PR TITLE
chore(ci): bump actions/cache v3 → v4

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -39,7 +39,7 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
 
       - name: Cache R packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-4.4-${{ hashFiles('**/DESCRIPTION') }}


### PR DESCRIPTION
## Summary
Bumps `actions/cache@v3` → `@v4` in the daily-update workflow.

`actions/cache@v3` runs on Node 20. GitHub forces deprecated Node 20 actions to Node 24 starting **June 16, 2026**, and removes Node 20 from runners **Sept 16, 2026**. This warning surfaced in the 2026-06-11 workflow run. Bumping to v4 keeps the action supported.

## Notes
- Only the cache action needed bumping; `actions/checkout` is already at `@v4`.
- No behavior change — same cache key/path config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)